### PR TITLE
Clipboard-related fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,13 @@ include = [ "**/*.rs", "Cargo.toml"]
 [dependencies]
 sdl2 = "0.34.3"
 gl = "0.14.0"
-clipboard = "0.5"
 egui = "0.10.0"
+
+[dependencies.clipboard]
+package = "cli-clipboard"
+#version = "0.5"
+version = "0.2"
+optional = true
+
+[features]
+default = ["clipboard"]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,40 @@
+#[derive(Clone, Copy, Debug)]
+pub struct Error;
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, _f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        Ok(())
+    }
+}
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+pub trait ClipboardProvider: Sized {
+    fn new() -> Result<Self>;
+    fn get_contents(&mut self) -> Result<String>;
+    fn set_contents(&mut self, contents: String) -> Result<()>;
+    fn clear(&mut self) -> Result<()>;
+}
+
+pub struct ClipboardContext {
+    contents: String,
+}
+
+impl ClipboardProvider for ClipboardContext {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            contents: Default::default(),
+        })
+    }
+    fn get_contents(&mut self) -> Result<String> {
+        Ok(self.contents.clone())
+    }
+    fn set_contents(&mut self, contents: String) -> Result<()> {
+        self.contents = contents;
+        Ok(())
+    }
+    fn clear(&mut self) -> Result<()> {
+        self.contents = Default::default();
+        Ok(())
+    }
+}


### PR DESCRIPTION
I made clipboard feature to be optional.
It is useful when SDL2 application runs in KMS/DRM mode directly without X11/Wayland because nope system-wide clipboard buffer in such case.

Also I dropped `clipboard` in favor of `cli-clipboard` crate to add support for wayland.

Finally I applied `cargo fmt` to get code looks well.