### PR TITLE
Reexports

### DIFF
--- a/examples/example/main.rs
+++ b/examples/example/main.rs
@@ -1,14 +1,12 @@
-extern crate gl;
-extern crate sdl2;
-
-use sdl2::event::Event;
-use sdl2::video::GLProfile;
-use std::time::Instant;
-
-use egui::{vec2, Color32, Image, Pos2, Rect};
-
 //Alias the backend to something less mouthful
 use egui_sdl2_gl as egui_backend;
+
+use egui_backend::{egui, gl, sdl2};
+use egui_backend::sdl2::event::Event;
+use egui_backend::sdl2::video::GLProfile;
+use std::time::Instant;
+
+use egui_backend::egui::{vec2, Color32, Image, Pos2, Rect};
 
 const SCREEN_WIDTH: u32 = 800;
 const SCREEN_HEIGHT: u32 = 600;

--- a/examples/example/triangle.rs
+++ b/examples/example/triangle.rs
@@ -138,11 +138,13 @@ impl Triangle {
 
             // Use shader program
             gl::UseProgram(self.program);
-            gl::BindFragDataLocation(self.program, 0, CString::new("out_color").unwrap().as_ptr());
+            let c_out_color = CString::new("out_color").unwrap();
+            gl::BindFragDataLocation(self.program, 0, c_out_color.as_ptr());
 
             // Specify the layout of the vertex data
+            let c_position = CString::new("position").unwrap();
             let pos_attr =
-                gl::GetAttribLocation(self.program, CString::new("position").unwrap().as_ptr());
+                gl::GetAttribLocation(self.program, c_position.as_ptr());
             gl::EnableVertexAttribArray(pos_attr as GLuint);
             gl::VertexAttribPointer(
                 pos_attr as GLuint,

--- a/examples/example/triangle.rs
+++ b/examples/example/triangle.rs
@@ -2,9 +2,8 @@
 // based on the example from:
 // https://github.com/brendanzab/gl-rs/blob/master/gl/examples/triangle.rs
 
-extern crate gl;
-
-use gl::types::*;
+use egui_sdl2_gl::gl;
+use egui_sdl2_gl::gl::types::*;
 use std::ffi::CString;
 use std::mem;
 use std::ptr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 #![warn(clippy::all)]
 #![allow(clippy::single_match)]
 
+// Re-export dependencies.
+pub use sdl2;
+pub use gl;
+pub use egui;
+
 mod painter;
 
 pub use painter::Painter;


### PR DESCRIPTION
Instead of re-declaring the dependencies on the user side, we can simply reexport them from this crate and use them directly. I updated the example to have an example of what I mean.