### PR TITLE
Make sdl2's "bundled" an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ include = ["**/*.rs", "Cargo.toml"]
 
 [dependencies.sdl2]
 version = "0.34.5"
-features = ["bundled"]
 
 [dependencies]
 gl = "0.14.0"
@@ -27,4 +26,5 @@ version = "0.2"
 optional = true
 
 [features]
-default = ["clipboard"]
+default = ["clipboard", "sdl2-bundled"]
+sdl2-bundled = ["sdl2/bundled"]


### PR DESCRIPTION
Some people prefer to use a precompiled sdl2 dll