### PR TITLE
Change painter to be public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 pub use egui;
 pub use gl;
 pub use sdl2;
-mod painter;
+pub mod painter;
 use painter::Painter;
 use {
     egui::*,


### PR DESCRIPTION
I ran into an issue while using the project (great setup by the way, been able to make some very nice UIs with this toolset, much easier than some of the others I've tried), where the Painter is currently set to private.

I was trying to create a struct that had all of the necessary parts for a window, so I could reference it later on. When I did this and rust was requiring the type for the painter object, it complained that it was private.

This change got me past that issue. I'm not sure if there may be a better way to solve this.

The struct looks something like this:
```
pub struct EguiWindowInstance {
    window: egui_sdl2_gl::sdl2::video::Window,
    _ctx: GLContext,
    pub egui_ctx: egui::CtxRef,
    event_pump: sdl2::EventPump,
    _controller: std::option::Option<sdl2::controller::GameController>,
    pub painter: egui_sdl2_gl::painter::Painter,
    egui_state: egui_sdl2_gl::EguiStateHandler
}
```

And the error I receive is this:

```
error[E0603]: module `painter` is private
  --> src/ui.rs:38:32
   |
38 |     pub painter: egui_sdl2_gl::painter::Painter,
   |                                ^^^^^^^ private module
   |
note: the module `painter` is defined here
  --> /home/d10sfan/.cargo/git/checkouts/egui_sdl2_gl-753d92545825dde7/6c23f73/src/lib.rs:8:1
   |
8  | mod painter;
   | ^^^^^^^^^^^^

```