### PR TITLE
Fix issue when keycode is None

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,45 +169,47 @@ pub fn input_to_egui(
         KeyUp {
             keycode, keymod, ..
         } => {
-            if let Some(key) = translate_virtual_key_code(keycode.unwrap()) {
-                state.modifiers = Modifiers {
-                    alt: (keymod & Mod::LALTMOD == Mod::LALTMOD)
-                        || (keymod & Mod::RALTMOD == Mod::RALTMOD),
-                    ctrl: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
-                        || (keymod & Mod::RCTRLMOD == Mod::RCTRLMOD),
-                    shift: (keymod & Mod::LSHIFTMOD == Mod::LSHIFTMOD)
-                        || (keymod & Mod::RSHIFTMOD == Mod::RSHIFTMOD),
-                    mac_cmd: keymod & Mod::LGUIMOD == Mod::LGUIMOD,
+            if !keycode.is_none() {
+                if let Some(key) = translate_virtual_key_code(keycode.unwrap()) {
+                    state.modifiers = Modifiers {
+                        alt: (keymod & Mod::LALTMOD == Mod::LALTMOD)
+                            || (keymod & Mod::RALTMOD == Mod::RALTMOD),
+                        ctrl: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
+                            || (keymod & Mod::RCTRLMOD == Mod::RCTRLMOD),
+                        shift: (keymod & Mod::LSHIFTMOD == Mod::LSHIFTMOD)
+                            || (keymod & Mod::RSHIFTMOD == Mod::RSHIFTMOD),
+                        mac_cmd: keymod & Mod::LGUIMOD == Mod::LGUIMOD,
 
-                    //TOD: Test on both windows and mac
-                    command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
-                        || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
-                };
+                        //TOD: Test on both windows and mac
+                        command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
+                            || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
+                    };
 
-                if state.modifiers.command && key == Key::C {
-                    println!("copy event");
-                    state.input.events.push(Event::Copy)
-                } else if state.modifiers.command && key == Key::X {
-                    println!("cut event");
-                    state.input.events.push(Event::Cut)
-                } else if state.modifiers.command && key == Key::V {
-                    println!("paste");
-                    if let Some(clipboard) = state.clipboard.as_mut() {
-                        match clipboard.get_contents() {
-                            Ok(contents) => {
-                                state.input.events.push(Event::Text(contents));
-                            }
-                            Err(err) => {
-                                eprintln!("Paste error: {}", err);
+                    if state.modifiers.command && key == Key::C {
+                        println!("copy event");
+                        state.input.events.push(Event::Copy)
+                    } else if state.modifiers.command && key == Key::X {
+                        println!("cut event");
+                        state.input.events.push(Event::Cut)
+                    } else if state.modifiers.command && key == Key::V {
+                        println!("paste");
+                        if let Some(clipboard) = state.clipboard.as_mut() {
+                            match clipboard.get_contents() {
+                                Ok(contents) => {
+                                    state.input.events.push(Event::Text(contents));
+                                }
+                                Err(err) => {
+                                    eprintln!("Paste error: {}", err);
+                                }
                             }
                         }
+                    } else {
+                        state.input.events.push(Event::Key {
+                            key,
+                            pressed: false,
+                            modifiers: state.modifiers,
+                        });
                     }
-                } else {
-                    state.input.events.push(Event::Key {
-                        key,
-                        pressed: false,
-                        modifiers: state.modifiers,
-                    });
                 }
             }
         }
@@ -215,26 +217,28 @@ pub fn input_to_egui(
         KeyDown {
             keycode, keymod, ..
         } => {
-            if let Some(key) = translate_virtual_key_code(keycode.unwrap()) {
-                state.modifiers = Modifiers {
-                    alt: (keymod & Mod::LALTMOD == Mod::LALTMOD)
-                        || (keymod & Mod::RALTMOD == Mod::RALTMOD),
-                    ctrl: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
-                        || (keymod & Mod::RCTRLMOD == Mod::RCTRLMOD),
-                    shift: (keymod & Mod::LSHIFTMOD == Mod::LSHIFTMOD)
-                        || (keymod & Mod::RSHIFTMOD == Mod::RSHIFTMOD),
-                    mac_cmd: keymod & Mod::LGUIMOD == Mod::LGUIMOD,
+            if !keycode.is_none() {
+                if let Some(key) = translate_virtual_key_code(keycode.unwrap()) {
+                    state.modifiers = Modifiers {
+                        alt: (keymod & Mod::LALTMOD == Mod::LALTMOD)
+                            || (keymod & Mod::RALTMOD == Mod::RALTMOD),
+                        ctrl: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
+                            || (keymod & Mod::RCTRLMOD == Mod::RCTRLMOD),
+                        shift: (keymod & Mod::LSHIFTMOD == Mod::LSHIFTMOD)
+                            || (keymod & Mod::RSHIFTMOD == Mod::RSHIFTMOD),
+                        mac_cmd: keymod & Mod::LGUIMOD == Mod::LGUIMOD,
 
-                    //TOD: Test on both windows and mac
-                    command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
-                        || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
-                };
+                        //TOD: Test on both windows and mac
+                        command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
+                            || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
+                    };
 
-                state.input.events.push(Event::Key {
-                    key,
-                    pressed: true,
-                    modifiers: state.modifiers,
-                });
+                    state.input.events.push(Event::Key {
+                        key,
+                        pressed: true,
+                        modifiers: state.modifiers,
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
Was getting a crash when I used the volume control keys on my keyboard. The crash looked like below:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /home/d10sfan/.cargo/git/checkouts/egui_sdl2_gl-753d92545825dde7/17b784f/src/lib.rs:172:67
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

These changes have it check to see if it is a None first, otherwise it'll go through.