### PR TITLE
fix CI + Update SDL2 crate v0.35

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: "egui_sdl2_gl"
+name: CI
 
 on:
   pull_request:
@@ -53,6 +53,10 @@ jobs:
         os: [ubuntu-latest]
         toolchain: [nightly, stable]
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Acquire source code
         uses: actions/checkout@v2
@@ -63,12 +67,6 @@ jobs:
           override: true
           profile: minimal
         id: toolchain
-      - name: Install requirements
-        run: |
-         if [ "$RUNNER_OS" == "Linux" ]; then
-          sudo apt-get update && sudo apt-get install -y libsdl2-dev libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libgl1-mesa-dev libglu1-mesa-dev libmpv-dev
-         fi
-        shell: bash
       - name: "Run build"
         run: RUST_BACKTRACE=1 cargo build
       - name: "Run tests"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: "egui_sdl2_gl"
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: "egui_sdl2_gl"
 
 on:
   pull_request:
@@ -53,10 +53,6 @@ jobs:
         os: [ubuntu-latest]
         toolchain: [nightly, stable]
 
-    defaults:
-      run:
-        shell: bash
-
     steps:
       - name: Acquire source code
         uses: actions/checkout@v2
@@ -67,7 +63,13 @@ jobs:
           override: true
           profile: minimal
         id: toolchain
+      - name: Install requirements
+        run: |
+         if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo apt-get update && sudo apt-get install -y libsdl2-dev libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libgl1-mesa-dev libglu1-mesa-dev libmpv-dev
+         fi
+        shell: bash
       - name: "Run build"
         run: RUST_BACKTRACE=1 cargo build
       - name: "Run tests"
-        run: RUST_BACKTRACE=1 cargo test
+        run: RUST_BACKTRACE=1 cargo test --features=use_epi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,10 +53,6 @@ jobs:
         os: [ubuntu-latest]
         toolchain: [nightly, stable]
 
-    defaults:
-      run:
-        shell: bash
-
     steps:
       - name: Acquire source code
         uses: actions/checkout@v2
@@ -67,6 +63,12 @@ jobs:
           override: true
           profile: minimal
         id: toolchain
+      - name: Install requirements
+        run: |
+         if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo apt-get update && sudo apt-get install -y libsdl2-dev libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libgl1-mesa-dev libglu1-mesa-dev libmpv-dev
+         fi
+        shell: bash
       - name: "Run build"
         run: RUST_BACKTRACE=1 cargo build
       - name: "Run tests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,15 @@ include = ["**/*.rs", "Cargo.toml"]
 # build = "build.rs"
 
 [dependencies]
-gl = "0.14.0"
-egui = "0.15.0"
-sdl2 = "0.34.5"
+gl = "0.14"
+egui = "0.15"
+sdl2 = "0.35"
 
-[dependencies.copypasta]
-version = "0.7"
+[dependencies.epi]
+version = "0.15"
 optional = true
 
 [features]
-clipboard = ["copypasta"]
 sdl2_unsafe_textures = ["sdl2/unsafe_textures"]
 sdl2_gfx = ["sdl2/gfx"]
 sdl2_mixer = ["sdl2/mixer"]
@@ -36,7 +35,7 @@ sdl2_use-vcpkg = ["sdl2/use-vcpkg"]
 sdl2_use-mac_framework = ["sdl2/use_mac_framework"]
 sdl2_bundled = ["sdl2/bundled"]
 sdl2_static-link = ["sdl2/static-link"]
-
+use_epi = ["epi"]
 
 [dev-dependencies]
 egui_demo_lib = "0.15"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Crates.io](https://img.shields.io/crates/v/egui_sdl2_gl.svg)](https://crates.io/crates/egui_sdl2_gl)
+[![Documentation](https://docs.rs/egui_sdl2_gl/badge.svg)](https://docs.rs/egui_sdl2_gl)
+[![CI](https://github.com/ArjunNair/egui_sdl2_gl/actions/workflows/ci.yml/badge.svg)](https://github.com/ArjunNair/egui_sdl2_gl/actions/workflows/ci.yml)
+
 # Egui backend for SDL2 + Open GL
 ![Example screenshot](/media/egui_sdl2_gl_example.png)
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 This is a backend implementation for [Egui](https://github.com/emilk/egui) that can be used with [SDL 2](https://github.com/Rust-SDL2/rust-sdl2) for events, audio, input et al and [OpenGL](https://github.com/brendanzab/gl-rs) for rendering.
 
 I've included an example in the examples folder to illustrate how the three can be used together. To run the example, do the following:
+
 ```
-cargo build --examples
-cargo run --example mix
-cargo run --example demo_lib
 cargo run --example basic
+cargo run --example mix
+cargo run --example demo_lib --features=use_epi
 ```
+
 Starting with v13.1 SDL2 is 'bundled' as a cargo requirement and so SDL2 needn't be setup separately. If, however, you wish to be in control of the SDL2 setup, you can remove the bundled feature from the cargo.toml and set up the SDL2 framework separately, as described in the SDL2 repo above.
 
 Note that using OpenGL involves wrapping **any**  Open GL call in an *unsafe* block. Have a look at the src/painter.rs file to see what I mean. This of course means that all bets are off when dealing with code inside the unsafe blocks, but that's the price to pay when dealing with raw OpenGL. 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,9 +1,8 @@
-use std::time::{Duration, Instant};
-
 use egui::Checkbox;
 use egui_backend::sdl2::video::GLProfile;
 use egui_backend::{egui, gl, sdl2};
-use egui_backend::{sdl2::event::Event, DpiScaling};
+use egui_backend::{sdl2::event::Event, DpiScaling, ShaderVersion};
+use std::time::Instant;
 // Alias the backend to something less mouthful
 use egui_sdl2_gl as egui_backend;
 use sdl2::video::SwapInterval;
@@ -16,15 +15,11 @@ fn main() {
     let video_subsystem = sdl_context.video().unwrap();
     let gl_attr = video_subsystem.gl_attr();
     gl_attr.set_context_profile(GLProfile::Core);
+    // On linux, OpenGL ES Mesa driver 22.0.0+ can be used like so:
+    // gl_attr.set_context_profile(GLProfile::GLES);
 
-    // Let OpenGL know we are dealing with SRGB colors so that it
-    // can do the blending correctly. Not setting the framebuffer
-    // leads to darkened, oversaturated colors.
-    gl_attr.set_framebuffer_srgb_compatible(true);
     gl_attr.set_double_buffer(true);
     gl_attr.set_multisample_samples(4);
-    // OpenGL 3.2 is the minimum that we will support.
-    gl_attr.set_context_version(3, 2);
 
     let window = video_subsystem
         .window(
@@ -39,11 +34,12 @@ fn main() {
 
     // Create a window context
     let _ctx = window.gl_create_context().unwrap();
-    debug_assert_eq!(gl_attr.context_profile(), GLProfile::Core);
-    debug_assert_eq!(gl_attr.context_version(), (3, 2));
-
     // Init egui stuff
-    let (mut painter, mut egui_state) = egui_backend::with_sdl2(&window, DpiScaling::Custom(2.0));
+    let shader_ver = ShaderVersion::Default;
+    // On linux use GLES SL 100+, like so:
+    // let shader_ver = ShaderVersion::Adaptive;
+    let (mut painter, mut egui_state) =
+        egui_backend::with_sdl2(&window, shader_ver, DpiScaling::Custom(2.0));
     let mut egui_ctx = egui::CtxRef::default();
     let mut event_pump = sdl_context.event_pump().unwrap();
 
@@ -87,7 +83,7 @@ fn main() {
 
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
         // Process ouput
-        egui_state.process_output(&egui_output);
+        egui_state.process_output(&window, &egui_output);
 
         // For default dpi scaling only, Update window when the size of resized window is very small (to avoid egui::CentralPanel distortions).
         // if egui_ctx.used_size() != painter.screen_rect.size() {
@@ -103,18 +99,10 @@ fn main() {
         // overlaying it:
         // First clear the background to something nice.
         unsafe {
-            // Clear the screen to black
+            // Clear the screen to green
             gl::ClearColor(0.3, 0.6, 0.3, 1.0);
             gl::Clear(gl::COLOR_BUFFER_BIT);
         }
-
-        if !egui_output.needs_repaint {
-            std::thread::sleep(Duration::from_millis(10))
-        }
-
-        painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
-
-        window.gl_swap_window();
 
         if !egui_output.needs_repaint {
             if let Some(event) = event_pump.wait_event_timeout(5) {
@@ -127,6 +115,8 @@ fn main() {
                 }
             }
         } else {
+            painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
+            window.gl_swap_window();
             for event in event_pump.poll_iter() {
                 match event {
                     Event::Quit { .. } => break 'running,

--- a/examples/demo_lib.rs
+++ b/examples/demo_lib.rs
@@ -1,12 +1,18 @@
-use std::time::{Duration, Instant};
-
-use egui_backend::sdl2::video::GLProfile;
-use egui_backend::{egui, gl, sdl2};
-use egui_backend::{sdl2::event::Event, DpiScaling};
+use egui_backend::{
+    egui,
+    epi::{
+        backend::{AppOutput, FrameBuilder},
+        App, IntegrationInfo,
+    },
+    get_frame_time, gl, sdl2,
+    sdl2::event::Event,
+    sdl2::video::GLProfile,
+    sdl2::video::SwapInterval,
+    DpiScaling, ShaderVersion, Signal,
+};
+use std::{sync::Arc, time::Instant};
 // Alias the backend to something less mouthful
 use egui_sdl2_gl as egui_backend;
-use sdl2::video::SwapInterval;
-
 const SCREEN_WIDTH: u32 = 800;
 const SCREEN_HEIGHT: u32 = 600;
 
@@ -48,52 +54,44 @@ fn main() {
         .unwrap();
 
     // Init egui stuff
-    let (mut painter, mut egui_state) = egui_backend::with_sdl2(&window, DpiScaling::Default);
-    let mut app = egui_demo_lib::DemoWindows::default();
+    let (mut painter, mut egui_state) =
+        egui_backend::with_sdl2(&window, ShaderVersion::Default, DpiScaling::Custom(1.25));
+    let mut app = egui_demo_lib::WrapApp::default();
     let mut egui_ctx = egui::CtxRef::default();
     let mut event_pump = sdl_context.event_pump().unwrap();
     let start_time = Instant::now();
-
-    // egui_ctx.set_visuals(egui::Visuals::light());
+    let repaint_signal = Arc::new(Signal::default());
+    let mut app_output = AppOutput::default();
 
     'running: loop {
         egui_state.input.time = Some(start_time.elapsed().as_secs_f64());
-
         egui_ctx.begin_frame(egui_state.input.take());
-        app.ui(&egui_ctx);
+        // Begin frame
+        let frame_time = get_frame_time(start_time);
+        let mut frame = FrameBuilder {
+            info: IntegrationInfo {
+                web_info: None,
+                cpu_usage: Some(frame_time),
+                native_pixels_per_point: Some(egui_state.native_pixels_per_point),
+                prefer_dark_mode: None,
+                name: "egui + sdl2 + gl",
+            },
+            tex_allocator: &mut painter,
+            output: &mut app_output,
+            repaint_signal: repaint_signal.clone(),
+        }
+        .build();
+        app.update(&egui_ctx, &mut frame);
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
         // Process ouput
-        egui_state.process_output(&egui_output);
-
-        // For default dpi scaling only, Update window when the size of resized window is very small (to avoid egui::CentralPanel distortions).
-        // if egui_ctx.used_size() != painter.screen_rect.size() {
-        //     println!("resized.");
-        //     let _size = egui_ctx.used_size();
-        //     let (w, h) = (_size.x as u32, _size.y as u32);
-        //     window.set_size(w, h).unwrap();
-        // }
-
-        let paint_jobs = egui_ctx.tessellate(paint_cmds);
-
-        // An example of how OpenGL can be used to draw custom stuff with egui
-        // overlaying it:
-        // First clear the background to something nice.
-        unsafe {
-            // Clear the screen to black
-            gl::ClearColor(0.3, 0.6, 0.3, 1.0);
-            gl::Clear(gl::COLOR_BUFFER_BIT);
+        egui_state.process_output(&window, &egui_output);
+        // Quite if needed.
+        if app_output.quit {
+            break 'running;
         }
-
-        if !egui_output.needs_repaint {
-            std::thread::sleep(Duration::from_millis(10))
-        }
-
-        painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
-
-        window.gl_swap_window();
-
-        if !egui_output.needs_repaint {
-            if let Some(event) = event_pump.wait_event_timeout(5) {
+		
+		if !egui_output.needs_repaint {
+            if let Some(event) = event_pump.wait_event_timeout(1000) {
                 match event {
                     Event::Quit { .. } => break 'running,
                     _ => {
@@ -113,5 +111,27 @@ fn main() {
                 }
             }
         }
+
+        // For default dpi scaling only, Update window when the size of resized window is very small (to avoid egui::CentralPanel distortions).
+        // if egui_ctx.used_size() != painter.screen_rect.size() {
+        //     println!("resized.");
+        //     let _size = egui_ctx.used_size();
+        //     let (w, h) = (_size.x as u32, _size.y as u32);
+        //     window.set_size(w, h).unwrap();
+        // }
+
+        let paint_jobs = egui_ctx.tessellate(paint_cmds);
+
+        // An example of how OpenGL can be used to draw custom stuff with egui
+        // overlaying it:
+        // First clear the background to something nice.
+        unsafe {
+            // Clear the screen to green
+            gl::ClearColor(0.3, 0.6, 0.3, 1.0);
+            gl::Clear(gl::COLOR_BUFFER_BIT);
+        }
+
+		painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
+        window.gl_swap_window();
     }
 }

--- a/examples/demo_lib.rs
+++ b/examples/demo_lib.rs
@@ -91,7 +91,7 @@ fn main() {
         }
 
         if !egui_output.needs_repaint {
-			// Reactive every 1 second.
+            // Reactive every 1 second.
             if let Some(event) = event_pump.wait_event_timeout(1000) {
                 match event {
                     Event::Quit { .. } => break 'running,

--- a/examples/demo_lib.rs
+++ b/examples/demo_lib.rs
@@ -89,8 +89,9 @@ fn main() {
         if app_output.quit {
             break 'running;
         }
-		
-		if !egui_output.needs_repaint {
+
+        if !egui_output.needs_repaint {
+			// Reactive every 1 second.
             if let Some(event) = event_pump.wait_event_timeout(1000) {
                 match event {
                     Event::Quit { .. } => break 'running,
@@ -131,7 +132,7 @@ fn main() {
             gl::Clear(gl::COLOR_BUFFER_BIT);
         }
 
-		painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
+        painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
         window.gl_swap_window();
     }
 }

--- a/examples/mix/main.rs
+++ b/examples/mix/main.rs
@@ -1,10 +1,9 @@
 use std::time::Instant;
-
 //Alias the backend to something less mouthful
 use egui_backend::egui::{vec2, Color32, Image};
 use egui_backend::sdl2::video::GLProfile;
 use egui_backend::{egui, gl, sdl2};
-use egui_backend::{sdl2::event::Event, DpiScaling};
+use egui_backend::{sdl2::event::Event, DpiScaling, ShaderVersion};
 use egui_sdl2_gl as egui_backend;
 use sdl2::video::SwapInterval;
 mod triangle;
@@ -53,7 +52,8 @@ fn main() {
         .unwrap();
 
     // Init egui stuff
-    let (mut painter, mut egui_state) = egui_backend::with_sdl2(&window, DpiScaling::Default);
+    let (mut painter, mut egui_state) =
+        egui_backend::with_sdl2(&window, ShaderVersion::Default, DpiScaling::Default);
     let mut egui_ctx = egui::CtxRef::default();
     let mut event_pump: sdl2::EventPump = sdl_context.event_pump().unwrap();
     let mut srgba: Vec<Color32> = Vec::new();
@@ -90,7 +90,7 @@ fn main() {
         // overlaying it:
         // First clear the background to something nice.
         unsafe {
-            // Clear the screen to black
+            // Clear the screen to green
             gl::ClearColor(0.3, 0.6, 0.3, 1.0);
             gl::Clear(gl::COLOR_BUFFER_BIT);
         }
@@ -137,7 +137,7 @@ fn main() {
 
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
         // Process ouput
-        egui_state.process_output(&egui_output);
+        egui_state.process_output(&window, &egui_output);
 
         let paint_jobs = egui_ctx.tessellate(paint_cmds);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,29 +210,33 @@ pub fn input_to_egui(
         KeyUp {
             keycode, keymod, ..
         } => {
-            if let Some(key_code) = keycode {
-                if let Some(key) = translate_virtual_key_code(key_code) {
-                    state.modifiers = Modifiers {
-                        alt: (keymod & Mod::LALTMOD == Mod::LALTMOD)
-                            || (keymod & Mod::RALTMOD == Mod::RALTMOD),
-                        ctrl: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
-                            || (keymod & Mod::RCTRLMOD == Mod::RCTRLMOD),
-                        shift: (keymod & Mod::LSHIFTMOD == Mod::LSHIFTMOD)
-                            || (keymod & Mod::RSHIFTMOD == Mod::RSHIFTMOD),
-                        mac_cmd: keymod & Mod::LGUIMOD == Mod::LGUIMOD,
+            let key_code = match keycode {
+                Some(key_code) => key_code,
+                _ => return,
+            };
+            let key = match translate_virtual_key_code(key_code) {
+                Some(key) => key,
+                _ => return,
+            };
+            state.modifiers = Modifiers {
+                alt: (keymod & Mod::LALTMOD == Mod::LALTMOD)
+                    || (keymod & Mod::RALTMOD == Mod::RALTMOD),
+                ctrl: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
+                    || (keymod & Mod::RCTRLMOD == Mod::RCTRLMOD),
+                shift: (keymod & Mod::LSHIFTMOD == Mod::LSHIFTMOD)
+                    || (keymod & Mod::RSHIFTMOD == Mod::RSHIFTMOD),
+                mac_cmd: keymod & Mod::LGUIMOD == Mod::LGUIMOD,
 
-                        //TOD: Test on both windows and mac
-                        command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
-                            || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
-                    };
+                //TOD: Test on both windows and mac
+                command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
+                    || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
+            };
 
-                    state.input.events.push(Event::Key {
-                        key,
-                        pressed: false,
-                        modifiers: state.modifiers,
-                    });
-                }
-            }
+            state.input.events.push(Event::Key {
+                key,
+                pressed: false,
+                modifiers: state.modifiers,
+            });
         }
 
         KeyDown {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,40 +238,45 @@ pub fn input_to_egui(
         KeyDown {
             keycode, keymod, ..
         } => {
-            if let Some(key_code) = keycode {
-                if let Some(key) = translate_virtual_key_code(key_code) {
-                    state.modifiers = Modifiers {
-                        alt: (keymod & Mod::LALTMOD == Mod::LALTMOD)
-                            || (keymod & Mod::RALTMOD == Mod::RALTMOD),
-                        ctrl: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
-                            || (keymod & Mod::RCTRLMOD == Mod::RCTRLMOD),
-                        shift: (keymod & Mod::LSHIFTMOD == Mod::LSHIFTMOD)
-                            || (keymod & Mod::RSHIFTMOD == Mod::RSHIFTMOD),
-                        mac_cmd: keymod & Mod::LGUIMOD == Mod::LGUIMOD,
+            let key_code = match keycode {
+                Some(key_code) => key_code,
+                _ => return,
+            };
 
-                        //TOD: Test on both windows and mac
-                        command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
-                            || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
-                    };
+            let key = match translate_virtual_key_code(key_code) {
+                Some(key) => key,
+                _ => return,
+            };
+            state.modifiers = Modifiers {
+                alt: (keymod & Mod::LALTMOD == Mod::LALTMOD)
+                    || (keymod & Mod::RALTMOD == Mod::RALTMOD),
+                ctrl: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
+                    || (keymod & Mod::RCTRLMOD == Mod::RCTRLMOD),
+                shift: (keymod & Mod::LSHIFTMOD == Mod::LSHIFTMOD)
+                    || (keymod & Mod::RSHIFTMOD == Mod::RSHIFTMOD),
+                mac_cmd: keymod & Mod::LGUIMOD == Mod::LGUIMOD,
 
-                    state.input.events.push(Event::Key {
-                        key,
-                        pressed: true,
-                        modifiers: state.modifiers,
-                    });
+                //TOD: Test on both windows and mac
+                command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
+                    || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
+            };
 
-                    if state.modifiers.command && key == Key::C {
-                        // println!("copy event");
-                        state.input.events.push(Event::Copy);
-                    } else if state.modifiers.command && key == Key::X {
-                        // println!("cut event");
-                        state.input.events.push(Event::Cut);
-                    } else if state.modifiers.command && key == Key::V {
-                        // println!("paste");
-                        if let Ok(contents) = window.subsystem().clipboard().clipboard_text() {
-                            state.input.events.push(Event::Text(contents));
-                        }
-                    }
+            state.input.events.push(Event::Key {
+                key,
+                pressed: true,
+                modifiers: state.modifiers,
+            });
+
+            if state.modifiers.command && key == Key::C {
+                // println!("copy event");
+                state.input.events.push(Event::Copy);
+            } else if state.modifiers.command && key == Key::X {
+                // println!("cut event");
+                state.input.events.push(Event::Cut);
+            } else if state.modifiers.command && key == Key::V {
+                // println!("paste");
+                if let Ok(contents) = window.subsystem().clipboard().clipboard_text() {
+                    state.input.events.push(Event::Text(contents));
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,8 @@ pub fn input_to_egui(
                         command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
                             || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
                     };
-					
-					state.input.events.push(Event::Key {
+
+                    state.input.events.push(Event::Key {
                         key,
                         pressed: false,
                         modifiers: state.modifiers,
@@ -253,14 +253,14 @@ pub fn input_to_egui(
                         command: (keymod & Mod::LCTRLMOD == Mod::LCTRLMOD)
                             || (keymod & Mod::LGUIMOD == Mod::LGUIMOD),
                     };
-					
-					state.input.events.push(Event::Key {
+
+                    state.input.events.push(Event::Key {
                         key,
                         pressed: true,
                         modifiers: state.modifiers,
                     });
-					
-					if state.modifiers.command && key == Key::C {
+
+                    if state.modifiers.command && key == Key::C {
                         // println!("copy event");
                         state.input.events.push(Event::Copy);
                     } else if state.modifiers.command && key == Key::X {

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -288,7 +288,9 @@ pub fn link_program(vs: GLuint, fs: GLuint) -> GLuint {
             let mut len: GLint = 0;
             gl::GetProgramiv(program, gl::INFO_LOG_LENGTH, &mut len);
             let mut buf = Vec::with_capacity(len as usize);
-            buf.set_len((len as usize) - 1); // subtract 1 to skip the trailing null character
+            // clippy not happy with this, broke the CI:
+            // error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+            // buf.set_len((len as usize) - 1); // subtract 1 to skip the trailing null character
             gl::GetProgramInfoLog(
                 program,
                 len,

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -255,7 +255,9 @@ pub fn compile_shader(src: &str, ty: GLenum) -> GLuint {
             let mut len = 0;
             gl::GetShaderiv(shader, gl::INFO_LOG_LENGTH, &mut len);
             let mut buf = Vec::with_capacity(len as usize);
-            buf.set_len((len as usize) - 1); // subtract 1 to skip the trailing null character
+            // clippy not happy with this, broke the CI:
+            // error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+            // buf.set_len((len as usize) - 1); // subtract 1 to skip the trailing null character
             gl::GetShaderInfoLog(
                 shader,
                 len,


### PR DESCRIPTION
- support GLES 3 on linux (on examples/basic.rs),
- support create/update rgba8 user texture.
- impl epi to Painter (Optional, can be enabled: features = ["use_epi"])  to support most demo lib functionality.
- native sdl2 clipboard support.
- fix reactive mode on demo_lib example.
- fix clippy.