### PR TITLE
Feature/update egui 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_sdl2_gl"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Arjun Nair <arjunair@gmail.com>"]
 edition = "2018"
 description = "Backend for Egui to use with sdl2-rs and open gl"
@@ -15,11 +15,11 @@ include = ["**/*.rs", "Cargo.toml"]
 
 [dependencies]
 gl = "0.14"
-egui = "0.15"
+egui = "0.16"
 sdl2 = "0.35"
 
 [dependencies.epi]
-version = "0.15"
+version = "0.16"
 optional = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,4 @@ sdl2_static-link = ["sdl2/static-link"]
 use_epi = ["epi"]
 
 [dev-dependencies]
-egui_demo_lib = "0.15"
+egui_demo_lib = "0.16"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -115,7 +115,7 @@ fn main() {
                 }
             }
         } else {
-            painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
+            painter.paint_jobs(None, paint_jobs, &egui_ctx.font_image());
             window.gl_swap_window();
             for event in event_pump.poll_iter() {
                 match event {

--- a/examples/demo_lib.rs
+++ b/examples/demo_lib.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "use_epi"))]
+compile_error!("feature \"use_epi\" must be used");
+
 use egui_backend::{
     egui,
     epi::{

--- a/examples/demo_lib.rs
+++ b/examples/demo_lib.rs
@@ -3,16 +3,14 @@ compile_error!("feature \"use_epi\" must be used");
 
 use egui_backend::{
     egui,
-    epi::{
-        backend::{AppOutput, FrameBuilder},
-        App, IntegrationInfo,
-    },
+    epi::{App, Frame, IntegrationInfo},
     get_frame_time, gl, sdl2,
     sdl2::event::Event,
     sdl2::video::GLProfile,
     sdl2::video::SwapInterval,
     DpiScaling, ShaderVersion, Signal,
 };
+use epi::backend::FrameData;
 use std::{sync::Arc, time::Instant};
 // Alias the backend to something less mouthful
 use egui_sdl2_gl as egui_backend;
@@ -64,14 +62,13 @@ fn main() {
     let mut event_pump = sdl_context.event_pump().unwrap();
     let start_time = Instant::now();
     let repaint_signal = Arc::new(Signal::default());
-    let mut app_output = AppOutput::default();
 
     'running: loop {
         egui_state.input.time = Some(start_time.elapsed().as_secs_f64());
         egui_ctx.begin_frame(egui_state.input.take());
         // Begin frame
         let frame_time = get_frame_time(start_time);
-        let mut frame = FrameBuilder {
+        let mut frame = Frame::new(FrameData {
             info: IntegrationInfo {
                 web_info: None,
                 cpu_usage: Some(frame_time),
@@ -79,17 +76,16 @@ fn main() {
                 prefer_dark_mode: None,
                 name: "egui + sdl2 + gl",
             },
-            tex_allocator: &mut painter,
-            output: &mut app_output,
+            output: Default::default(),
             repaint_signal: repaint_signal.clone(),
-        }
-        .build();
+        });
+
         app.update(&egui_ctx, &mut frame);
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
         // Process ouput
         egui_state.process_output(&window, &egui_output);
         // Quite if needed.
-        if app_output.quit {
+        if frame.take_app_output().quit {
             break 'running;
         }
 
@@ -135,7 +131,7 @@ fn main() {
             gl::Clear(gl::COLOR_BUFFER_BIT);
         }
 
-        painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
+        painter.paint_jobs(None, paint_jobs, &egui_ctx.font_image());
         window.gl_swap_window();
     }
 }

--- a/examples/mix/main.rs
+++ b/examples/mix/main.rs
@@ -145,7 +145,7 @@ fn main() {
         // Use this only if egui is being used for all drawing and you aren't mixing your own Open GL
         // drawing calls with it.
         // Since we are custom drawing an OpenGL Triangle we don't need egui to clear the background.
-        painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
+        painter.paint_jobs(None, paint_jobs, &egui_ctx.font_image());
 
         window.gl_swap_window();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,9 +295,12 @@ pub fn input_to_egui(
             if sdl.keyboard().mod_state() & Mod::LCTRLMOD == Mod::LCTRLMOD
                 || sdl.keyboard().mod_state() & Mod::RCTRLMOD == Mod::RCTRLMOD
             {
-                state.input.zoom_delta *= (delta.y / 125.0).exp();
+                state
+                    .input
+                    .events
+                    .push(Event::Zoom((delta.y / 125.0).exp()));
             } else {
-                state.input.scroll_delta = delta;
+                state.input.events.push(Event::Scroll(delta));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ impl Default for Signal {
     }
 }
 #[cfg(feature = "use_epi")]
-use epi::RepaintSignal;
+use epi::backend::RepaintSignal;
 #[cfg(feature = "use_epi")]
 impl RepaintSignal for Signal {
     fn request_repaint(&self) {}

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -7,7 +7,7 @@ use core::mem;
 use core::ptr;
 use core::str;
 use egui::{
-    paint::{Color32, Mesh, Texture},
+    epaint::{Color32, FontImage, Mesh},
     vec2, ClippedMesh, Pos2, Rect,
 };
 use gl::types::{GLchar, GLenum, GLint, GLsizeiptr, GLsync, GLuint};
@@ -434,7 +434,7 @@ impl Painter {
         }
     }
 
-    fn upload_egui_texture(&mut self, texture: &Texture) {
+    fn upload_egui_texture(&mut self, texture: &FontImage) {
         if self.egui_texture_version == Some(texture.version) {
             return; // No change
         }
@@ -602,7 +602,7 @@ impl Painter {
         &mut self,
         bg_color: Option<Color32>,
         meshes: Vec<ClippedMesh>,
-        egui_texture: &Texture,
+        egui_texture: &FontImage,
     ) {
         unsafe {
             gl::PixelStorei(gl::UNPACK_ROW_LENGTH, 0);

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -1,7 +1,5 @@
 extern crate gl;
 extern crate sdl2;
-#[cfg(feature = "use_epi")]
-use crate::epi::{Image, TextureAllocator};
 use crate::ShaderVersion;
 use core::mem;
 use core::ptr;
@@ -825,18 +823,6 @@ impl Painter {
             gl::DeleteTextures(1, &self.egui_texture);
             gl::DeleteVertexArrays(1, &self.vertex_array);
         }
-    }
-}
-
-#[cfg(feature = "use_epi")]
-impl TextureAllocator for Painter {
-    fn alloc(&self, image: Image) -> egui::TextureId {
-        let sizes = (image.size[0], image.size[1]);
-        self.new_user_texture(sizes, &image.pixels, true)
-    }
-
-    fn free(&self, id: egui::TextureId) {
-        self.free_user_texture(id)
     }
 }
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -1,7 +1,7 @@
 extern crate gl;
 extern crate sdl2;
 #[cfg(feature = "use_epi")]
-use crate::epi::TextureAllocator;
+use crate::epi::{Image, TextureAllocator};
 use crate::ShaderVersion;
 use core::mem;
 use core::ptr;
@@ -830,15 +830,12 @@ impl Painter {
 
 #[cfg(feature = "use_epi")]
 impl TextureAllocator for Painter {
-    fn alloc_srgba_premultiplied(
-        &mut self,
-        size: (usize, usize),
-        srgba_pixels: &[egui::Color32],
-    ) -> egui::TextureId {
-        self.new_user_texture(size, srgba_pixels, true)
+    fn alloc(&self, image: Image) -> egui::TextureId {
+        let sizes = (image.size[0], image.size[1]);
+        self.new_user_texture(sizes, &image.pixels, true)
     }
 
-    fn free(&mut self, id: egui::TextureId) {
+    fn free(&self, id: egui::TextureId) {
         self.free_user_texture(id)
     }
 }


### PR DESCRIPTION
upgrade crate to use `egui-0.16`

I'm not sure on the deletion of the implementation of `TextureAllocator` for `Painter`.
The examples don't appear to be broken with `--features use_epi`
