### PR TITLE
Bump egui version support to v0.22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # Custom files
 *.dll
+
+# Visual Studio files
+.vs/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["sdl2", "opengl", "egui", "gui", "gamedev"]
 include = ["**/*.rs", "Cargo.toml"]
 
 [dependencies]
+ahash = "0.8.3"
 gl = "0.14.0"
 egui = "0.22.0"
 sdl2 = { version = "0.35.2", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["**/*.rs", "Cargo.toml"]
 [dependencies]
 gl = "0.14.0"
 egui = "0.22.0"
-sdl2 = "0.35.2"
+sdl2 = { version = "0.35.2", features = ["bundled"] }
 
 [dependencies.epi]
 version = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["sdl2", "opengl", "egui", "gui", "gamedev"]
 include = ["**/*.rs", "Cargo.toml"]
 
 [dependencies]
-ahash = "0.8.3"
-gl = "0.14.0"
-egui = "0.22.0"
-sdl2 = { version = "0.35.2", features = ["bundled"] }
+ahash = "~0.8"
+gl = "~0.14"
+egui = "~0.22"
+sdl2 = { version = "~0.35", features = ["bundled"] }
 
 [dependencies.epi]
 version = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,14 @@ repository = "https://github.com/ArjunNair/egui_sdl2_gl"
 categories = ["gui", "graphics"]
 keywords = ["sdl2", "opengl", "egui", "gui", "gamedev"]
 include = ["**/*.rs", "Cargo.toml"]
-# build = "build.rs"
 
 [dependencies]
-gl = "0.14"
-egui = "0.16"
-sdl2 = "0.35"
+gl = "0.14.0"
+egui = "0.22.0"
+sdl2 = "0.35.2"
 
 [dependencies.epi]
-version = "0.16"
+version = "0.17"
 optional = true
 
 [features]
@@ -38,4 +37,4 @@ sdl2_static-link = ["sdl2/static-link"]
 use_epi = ["epi"]
 
 [dev-dependencies]
-egui_demo_lib = "0.16"
+egui_demo_lib = "0.22.0"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -110,7 +110,7 @@ fn main() {
         painter.paint_jobs(None, textures_delta, paint_jobs);
         window.gl_swap_window();
 
-        if repaint_after.is_zero() {
+        if !repaint_after.is_zero() {
             if let Some(event) = event_pump.wait_event_timeout(5) {
                 match event {
                     Event::Quit { .. } => break 'running,

--- a/examples/demo_lib.rs
+++ b/examples/demo_lib.rs
@@ -3,7 +3,7 @@ compile_error!("feature \"use_epi\" must be used");
 
 use egui_backend::{
     egui::{self, FullOutput},
-    epi::{App, Frame, IntegrationInfo},
+    epi::{Frame, IntegrationInfo},
     get_frame_time, gl, sdl2,
     sdl2::event::Event,
     sdl2::video::GLProfile,
@@ -58,7 +58,7 @@ fn main() {
     let (mut painter, mut egui_state) =
         egui_backend::with_sdl2(&window, ShaderVersion::Default, DpiScaling::Custom(1.25));
     let mut demo_windows = egui_demo_lib::DemoWindows::default();
-    let mut egui_ctx = egui::Context::default();
+    let egui_ctx = egui::Context::default();
     let mut event_pump = sdl_context.event_pump().unwrap();
     let start_time = Instant::now();
     let repaint_signal = Arc::new(Signal::default());
@@ -68,7 +68,7 @@ fn main() {
         egui_ctx.begin_frame(egui_state.input.take());
         // Begin frame
         let frame_time = get_frame_time(start_time);
-        let mut frame = Frame::new(FrameData {
+        let frame = Frame::new(FrameData {
             info: IntegrationInfo {
                 web_info: None,
                 cpu_usage: Some(frame_time),

--- a/examples/mix/main.rs
+++ b/examples/mix/main.rs
@@ -1,4 +1,5 @@
 use std::time::Instant;
+
 //Alias the backend to something less mouthful
 use egui_backend::egui::{vec2, Color32, FullOutput, Image};
 use egui_backend::sdl2::video::GLProfile;
@@ -54,7 +55,7 @@ fn main() {
     // Init egui stuff
     let (mut painter, mut egui_state) =
         egui_backend::with_sdl2(&window, ShaderVersion::Default, DpiScaling::Default);
-    let mut egui_ctx = egui::Context::default();
+    let egui_ctx = egui::Context::default();
     let mut event_pump: sdl2::EventPump = sdl_context.event_pump().unwrap();
     let mut srgba: Vec<Color32> = Vec::new();
 

--- a/examples/mix/main.rs
+++ b/examples/mix/main.rs
@@ -135,7 +135,12 @@ fn main() {
             }
         });
 
-        let FullOutput{platform_output, repaint_after, textures_delta, shapes} = egui_ctx.end_frame();
+        let FullOutput {
+            platform_output,
+            repaint_after,
+            textures_delta,
+            shapes,
+        } = egui_ctx.end_frame();
         // Process ouput
         egui_state.process_output(&window, &platform_output);
 

--- a/examples/mix/main.rs
+++ b/examples/mix/main.rs
@@ -145,7 +145,7 @@ fn main() {
         // Use this only if egui is being used for all drawing and you aren't mixing your own Open GL
         // drawing calls with it.
         // Since we are custom drawing an OpenGL Triangle we don't need egui to clear the background.
-        painter.paint_jobs(None, paint_jobs);
+        painter.paint_jobs(None, textures_delta, paint_jobs);
 
         window.gl_swap_window();
 

--- a/examples/mix/main.rs
+++ b/examples/mix/main.rs
@@ -155,7 +155,7 @@ fn main() {
 
         window.gl_swap_window();
 
-        if repaint_after.is_zero() {
+        if !repaint_after.is_zero() {
             if let Some(event) = event_pump.wait_event_timeout(5) {
                 match event {
                     Event::Quit { .. } => break 'running,

--- a/examples/mix/main.rs
+++ b/examples/mix/main.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 //Alias the backend to something less mouthful
-use egui_backend::egui::{vec2, Color32, Image};
+use egui_backend::egui::{vec2, Color32, FullOutput, Image};
 use egui_backend::sdl2::video::GLProfile;
 use egui_backend::{egui, gl, sdl2};
 use egui_backend::{sdl2::event::Event, DpiScaling, ShaderVersion};
@@ -54,7 +54,7 @@ fn main() {
     // Init egui stuff
     let (mut painter, mut egui_state) =
         egui_backend::with_sdl2(&window, ShaderVersion::Default, DpiScaling::Default);
-    let mut egui_ctx = egui::CtxRef::default();
+    let mut egui_ctx = egui::Context::default();
     let mut event_pump: sdl2::EventPump = sdl_context.event_pump().unwrap();
     let mut srgba: Vec<Color32> = Vec::new();
 
@@ -135,21 +135,21 @@ fn main() {
             }
         });
 
-        let (egui_output, paint_cmds) = egui_ctx.end_frame();
+        let FullOutput{platform_output, repaint_after, textures_delta, shapes} = egui_ctx.end_frame();
         // Process ouput
-        egui_state.process_output(&window, &egui_output);
+        egui_state.process_output(&window, &platform_output);
 
-        let paint_jobs = egui_ctx.tessellate(paint_cmds);
+        let paint_jobs = egui_ctx.tessellate(shapes);
 
         // Note: passing a bg_color to paint_jobs will clear any previously drawn stuff.
         // Use this only if egui is being used for all drawing and you aren't mixing your own Open GL
         // drawing calls with it.
         // Since we are custom drawing an OpenGL Triangle we don't need egui to clear the background.
-        painter.paint_jobs(None, paint_jobs, &egui_ctx.font_image());
+        painter.paint_jobs(None, paint_jobs);
 
         window.gl_swap_window();
 
-        if !egui_output.needs_repaint {
+        if repaint_after.is_zero() {
             if let Some(event) = event_pump.wait_event_timeout(5) {
                 match event {
                     Event::Quit { .. } => break 'running,

--- a/examples/mix/main.rs
+++ b/examples/mix/main.rs
@@ -142,7 +142,7 @@ fn main() {
             textures_delta,
             shapes,
         } = egui_ctx.end_frame();
-        // Process ouput
+        // Process output
         egui_state.process_output(&window, &platform_output);
 
         let paint_jobs = egui_ctx.tessellate(shapes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ impl EguiStateHandler {
         input_to_egui(window, event, painter, self);
     }
 
-    pub fn process_output(&mut self, window: &sdl2::video::Window, egui_output: &egui::Output) {
+    pub fn process_output(&mut self, window: &sdl2::video::Window, egui_output: &egui::PlatformOutput) {
         if !egui_output.copied_text.is_empty() {
             let copied_text = egui_output.copied_text.clone();
             {
@@ -208,7 +208,7 @@ pub fn input_to_egui(
         }
 
         KeyUp {
-            keycode, keymod, ..
+            keycode, keymod, repeat, ..
         } => {
             let key_code = match keycode {
                 Some(key_code) => key_code,
@@ -235,12 +235,13 @@ pub fn input_to_egui(
             state.input.events.push(Event::Key {
                 key,
                 pressed: false,
+                repeat,
                 modifiers: state.modifiers,
             });
         }
 
         KeyDown {
-            keycode, keymod, ..
+            keycode, keymod, repeat, ..
         } => {
             let key_code = match keycode {
                 Some(key_code) => key_code,
@@ -268,6 +269,7 @@ pub fn input_to_egui(
             state.input.events.push(Event::Key {
                 key,
                 pressed: true,
+                repeat,
                 modifiers: state.modifiers,
             });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,11 @@ impl EguiStateHandler {
         input_to_egui(window, event, painter, self);
     }
 
-    pub fn process_output(&mut self, window: &sdl2::video::Window, egui_output: &egui::PlatformOutput) {
+    pub fn process_output(
+        &mut self,
+        window: &sdl2::video::Window,
+        egui_output: &egui::PlatformOutput,
+    ) {
         if !egui_output.copied_text.is_empty() {
             let copied_text = egui_output.copied_text.clone();
             {
@@ -208,7 +212,10 @@ pub fn input_to_egui(
         }
 
         KeyUp {
-            keycode, keymod, repeat, ..
+            keycode,
+            keymod,
+            repeat,
+            ..
         } => {
             let key_code = match keycode {
                 Some(key_code) => key_code,
@@ -241,7 +248,10 @@ pub fn input_to_egui(
         }
 
         KeyDown {
-            keycode, keymod, repeat, ..
+            keycode,
+            keymod,
+            repeat,
+            ..
         } => {
             let key_code = match keycode {
                 Some(key_code) => key_code,

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -690,6 +690,10 @@ impl Painter {
             gl::Disable(gl::FRAMEBUFFER_SRGB);
             gl::Disable(gl::BLEND);
         }
+
+        for texture_id in textures_delta.free {
+            self.free_texture(texture_id);
+        }
     }
 
     fn paint_mesh(&self, mesh: &Mesh) {

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -6,7 +6,7 @@ use core::ptr;
 use core::str;
 use egui::{
     epaint::{Color32, FontImage, Mesh},
-    vec2, ClippedMesh, Pos2, Rect,
+    vec2, ClippedPrimitive, Pos2, Rect,
 };
 use gl::types::{GLchar, GLenum, GLint, GLsizeiptr, GLsync, GLuint};
 use std::ffi::CString;
@@ -599,7 +599,7 @@ impl Painter {
     pub fn paint_jobs(
         &mut self,
         bg_color: Option<Color32>,
-        meshes: Vec<ClippedMesh>,
+        meshes: Vec<ClippedPrimitive>,
         egui_texture: &FontImage,
     ) {
         unsafe {
@@ -646,7 +646,7 @@ impl Painter {
             let screen_x = canvas_width as f32;
             let screen_y = canvas_height as f32;
 
-            for ClippedMesh(clip_rect, mesh) in meshes {
+            for ClippedPrimitive{clip_rect, primitive: mesh} in meshes {
                 if let Some(texture_id) = self.get_texture(mesh.texture_id) {
                     gl::BindTexture(gl::TEXTURE_2D, texture_id);
                     let clip_min_x = pixels_per_point * clip_rect.min.x;


### PR DESCRIPTION
I updated this integration so that it can be used in the latest version of `egui` (v0.22 at the time of writing). Majority of the work involved updating `painter.rs` to support the breaking changes introduced by `egui` since v0.17. The changes were primarily based on the way [`egui-glium`](https://github.com/emilk/egui/tree/master/crates/egui_glium) does things, but the overall structure should not be too different from the implementation for v0.16.

The demos have been updated as well, but they need to be updated more as well to consider `egui`'s changes to `repaint_after`. On the other hand, I can confirm that they are working, as shown below:

<figure>
  <img src="https://github.com/ArjunNair/egui_sdl2_gl/assets/7175885/33ba40d8-4c63-461e-a4ae-d83891b0b6e8" alt="Working mix example."/>
  <figcaption>Working mix example.</figcaption>
</figure>
<br /><br />
<figure>
  <img src="https://github.com/ArjunNair/egui_sdl2_gl/assets/7175885/93f88507-62d2-40e7-9d04-4c77766fc379" alt="Working basic example."/>
  <figcaption>Working basic example.</figcaption>
</figure>
<br /><br />
<figure>
  <img src="https://github.com/ArjunNair/egui_sdl2_gl/assets/7175885/82a57227-b002-4e5d-a357-9953afa99e99" alt="Working demo_lib example. Accented 'é' in the 'Bézier Curve' window is not working for some reason."/>
  <figcaption>Working <code>demo_lib</code> example. Accented 'é' in the 'Bézier Curve' window is not working for some reason.</figcaption>
</figure>
<br /><br />

`Cargo.toml` was also updated to use the bundled SDL 2 crate, though we might want to change that, pending review. It was also updated to bump the versions of our dependencies, and also support their patch versions so that we don't have to keep on updating this integration just keep up with the patch versions of dependencies. Major and minor versions are pinned, however, to ensure that we can deal with any breaking changes the dependencies would introduce.

`.gitignore` has also been updated to ignore `.vs/` directories since I am developing with Rust using Visual Studio with the [`rust-analyzer.vs`](https://github.com/kitamstudios/rust-analyzer.vs) plugin.

More work can be done to improve the code and overall developer experience, but this PR should be a start towards such a direction.