### PR TITLE
change sdl2 "bundled" embedding to default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,15 @@ include = ["**/*.rs", "Cargo.toml"]
 ahash = "~0.8"
 gl = "~0.14"
 egui = "~0.22"
-sdl2 = { version = "~0.35", features = ["bundled"] }
+sdl2 = { version = "~0.35" }
 
 [dependencies.epi]
 version = "0.17"
 optional = true
 
 [features]
+default-features = ["sdl2_bundled"]
+
 sdl2_unsafe_textures = ["sdl2/unsafe_textures"]
 sdl2_gfx = ["sdl2/gfx"]
 sdl2_mixer = ["sdl2/mixer"]


### PR DESCRIPTION
This PR removes `bundled` feature declaration on the `sdl2` dependency and moves it to `default-features`.

This allows the crate user to disable `bundled` mode using `default-features=false` when declaring `egui_sdl2_gl` as a dependency.

On MacOS `sdl2-sys` building seems to broken due to XCode changes that are causing compilation failure of the underlying C library, using a shared/dynamic library avoids the need to build.  This is, however, not possible if `bundled` is enforced.