### PR TITLE
Fix "Could't get DPI" on VMs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,11 +88,13 @@ pub fn with_sdl2(
     shader_ver: ShaderVersion,
     scale: DpiScaling,
 ) -> (Painter, EguiStateHandler) {
+    let display_dpi = window
+        .subsystem()
+        .display_dpi(0)
+        .unwrap_or((96.0, 96.0, 96.0));
     let scale = match scale {
-        DpiScaling::Default => 96.0 / window.subsystem().display_dpi(0).unwrap().0,
-        DpiScaling::Custom(custom) => {
-            (96.0 / window.subsystem().display_dpi(0).unwrap().0) * custom
-        }
+        DpiScaling::Default => 96.0 / display_dpi.0,
+        DpiScaling::Custom(custom) => (96.0 / display_dpi.0) * custom,
     };
     let painter = painter::Painter::new(window, scale, shader_ver);
     EguiStateHandler::new(painter)


### PR DESCRIPTION
On virtual machines for some reason sdl2 is unable to get the display DPI.

```
thread 'main' panicked at /home/carlos/.cargo/registry/src/index.crates.io-6f17d22bba15001f/egui_sdl2_gl-0.22.1/src/lib.rs:94:55:
called `Result::unwrap()` on an `Err` value: "Couldn't get DPI"
```

This change proposes to set a default value in case sdl2 fails to obtain the actual value.