### PR TITLE
Also allow sdl2 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["**/*.rs", "Cargo.toml", "/shaders"]
 ahash = "~0.8"
 gl = "~0.14"
 egui = "~0.32"
-sdl2 = { version = ">= 0.36, < 0.38" }
+sdl2 = { version = ">= 0.36, < 0.39" }
 memoffset = "0.9.0"
 
 [dependencies.epi]


### PR DESCRIPTION
sdl2 0.36, 0.37, 0.38 all are perfectly compatible, so here is a non-breaking change to allow sdl2 0.38 users to use this library.